### PR TITLE
Issue 690

### DIFF
--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -30,7 +30,7 @@ public typealias OptionValue = AnyObject
 #endif
 
 public class Credentials : RouterMiddleware {
-    private let ERROR_NO_SESSION = "No session is available. Session must be "
+    private static let ERROR_NO_SESSION = "No session is available. Session is required to authenticate user."
     
     var nonRedirectingPlugins = [CredentialsPluginProtocol]()
     var redirectingPlugins = [String : CredentialsPluginProtocol]()
@@ -66,9 +66,9 @@ public class Credentials : RouterMiddleware {
         else {
             // session is not available; return error
 #if os(Linux)
-            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey: ERROR_NO_SESSION])
+            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey: Credentials.ERROR_NO_SESSION])
 #else
-            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString: ERROR_NO_SESSION])
+            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString: Credentials.ERROR_NO_SESSION])
 #endif
             next()
             return
@@ -254,9 +254,9 @@ public class Credentials : RouterMiddleware {
             else {
                 // session is not available; return error
 #if os(Linux)
-                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey:"Failed to redirect unauthorized request"])
+                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey: Credentials.ERROR_NO_SESSION])
 #else
-                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString:"Failed to redirect unauthorized request"])
+                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString: Credentials.ERROR_NO_SESSION])
 #endif
                 next()
                 return

--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -30,6 +30,7 @@ public typealias OptionValue = AnyObject
 #endif
 
 public class Credentials : RouterMiddleware {
+    private let ERROR_NO_SESSION = "No session is available. Session must be "
     
     var nonRedirectingPlugins = [CredentialsPluginProtocol]()
     var redirectingPlugins = [String : CredentialsPluginProtocol]()
@@ -61,6 +62,16 @@ public class Credentials : RouterMiddleware {
                     }
                 }
             }
+        }
+        else {
+            // session is not available; return error
+#if os(Linux)
+            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey: ERROR_NO_SESSION])
+#else
+            response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString: ERROR_NO_SESSION])
+#endif
+            next()
+            return
         }
 
         var pluginIndex = -1
@@ -201,45 +212,54 @@ public class Credentials : RouterMiddleware {
     
     public func authenticate (credentialsType: String, successRedirect: String?=nil, failureRedirect: String?=nil) -> RouterHandler {
         return { request, response, next in
-            if let plugin = self.redirectingPlugins[credentialsType] {
-                plugin.authenticate(request: request, response: response, options: self.options,
-                                    onSuccess: { userProfile in
-                                        if let session = request.session {
+            if let session = request.session {
+                if let plugin = self.redirectingPlugins[credentialsType] {
+                    plugin.authenticate(request: request, response: response, options: self.options,
+                                        onSuccess: { userProfile in
                                             var profile = [String:String]()
                                             profile["displayName"] = userProfile.displayName
                                             profile["provider"] = credentialsType
                                             profile["id"] = userProfile.id
                                             session["userProfile"] = JSON(profile as OptionValue)
-                                        
+
                                             var redirect : String?
                                             if session["returnTo"].type != .null  {
                                                 redirect = session["returnTo"].stringValue
                                                 session.remove(key: "returnTo")
                                             }
                                             self.redirectAuthorized(response: response, path: redirect ?? successRedirect)
-                                            
-                                        }
-                                        next()
-                    },
-                                    onFailure: { _, _ in
-                                        self.redirectUnauthorized(response: response, path: failureRedirect)
-                    },
-                                    onPass: { _, _ in
-                                        self.redirectUnauthorized(response: response, path: failureRedirect)
-                    },
-                                    inProgress: {
-                                        next()
+                                            next()
+                        },
+                                        onFailure: { _, _ in
+                                            self.redirectUnauthorized(response: response, path: failureRedirect)
+                        },
+                                        onPass: { _, _ in
+                                            self.redirectUnauthorized(response: response, path: failureRedirect)
+                        },
+                                        inProgress: {
+                                            next()
+                        }
+                    )
+                }
+                else {
+                    do {
+                        try response.status(.unauthorized).end()
                     }
-                )
+                    catch {
+                        Log.error("Failed to send response")
+                    }
+                    next()
+                }
             }
             else {
-                do {
-                    try response.status(.unauthorized).end()
-                }
-                catch {
-                    Log.error("Failed to send response")
-                }
+                // session is not available; return error
+#if os(Linux)
+                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey:"Failed to redirect unauthorized request"])
+#else
+                response.error = NSError(domain: "Credentials", code: 1, userInfo: [NSLocalizedDescriptionKey as NSString:"Failed to redirect unauthorized request"])
+#endif
                 next()
+                return
             }
         }
     }

--- a/Tests/Credentials/TestToken.swift
+++ b/Tests/Credentials/TestToken.swift
@@ -19,6 +19,7 @@ import XCTest
 
 import Kitura
 import KituraNet
+import KituraSession
 import KituraSys
 
 @testable import Credentials
@@ -68,6 +69,8 @@ class TestToken : XCTestCase {
 
     static func setupRouter() -> Router {
         let router = Router()
+
+        router.all(middleware: Session(secret: "Very very secret....."))
 
         let dummyTokenPlugin = DummyTokenPlugin()
         let credentials = Credentials()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add error message to denote that credentials cannot be used without session

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/IBM-Swift/Kitura/issues/690

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested Facebook Credentials without session on macOS and Ubuntu 15.10.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
