### PR TITLE
IBM-Swift/Kitura#711 Remove HTTPServer.listen parameter: notOnMainQueue

### DIFF
--- a/Tests/CredentialsTests/CredentialsTest.swift
+++ b/Tests/CredentialsTests/CredentialsTest.swift
@@ -71,8 +71,7 @@ extension CredentialsTest {
     }
 
     private func setupServer(port: Int, delegate: ServerDelegate) -> HTTPServer {
-        return HTTPServer.listen(port: port, delegate: delegate,
-                                 notOnMainQueue:true)
+        return HTTPServer.listen(port: port, delegate: delegate)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

