### PR TITLE
Fix String interpolation warnings on 3.1; remove force unwraps

### DIFF
--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -285,21 +285,26 @@ public class Credentials : RouterMiddleware {
                     userName = UserProfile.UserProfileName(familyName: familyName, givenName: givenName, middleName: middleName)
                 }
                 
-                var userEmails: Array<UserProfile.UserProfileEmail>?
-                if let emails = dictionary["emails"] as? [String], let types = dictionary["emailTypes"] as? [String] {
-                    userEmails = Array()
+                var userEmails: [UserProfile.UserProfileEmail]?
+
+                if let emails = dictionary["emails"] as? [String],
+                    let types = dictionary["emailTypes"] as? [String] {
+                    userEmails = []
+
                     for (index, email) in emails.enumerated() {
                         let userEmail = UserProfile.UserProfileEmail(value: email, type: types[index])
-                        userEmails!.append(userEmail)
+                        userEmails?.append(userEmail)
                     }
                 }
                 
-                var userPhotos: Array<UserProfile.UserProfilePhoto>?
+                var userPhotos: [UserProfile.UserProfilePhoto]?
+
                 if let photos = dictionary["photos"] as? [String] {
-                    userPhotos = Array()
+                    userPhotos = []
+
                     for photo in photos {
                         let userPhoto = UserProfile.UserProfilePhoto(photo)
-                        userPhotos!.append(userPhoto)
+                        userPhotos?.append(userPhoto)
                     }
                 }
                 

--- a/Tests/CredentialsTests/DummyTokenPlugin.swift
+++ b/Tests/CredentialsTests/DummyTokenPlugin.swift
@@ -47,9 +47,9 @@ public class DummyTokenPlugin : CredentialsPluginProtocol {
                 let userProfile = UserProfile(id: "123", displayName: "Dummy User", provider: self.name)
                 let newCacheElement = BaseCacheElement(profile: userProfile)
                 #if os(OSX)
-                    self.usersCache!.setObject(newCacheElement, forKey: token as NSString)
+                    self.usersCache?.setObject(newCacheElement, forKey: token as NSString)
                 #else
-                    self.usersCache!.setObject(newCacheElement, forKey: NSString(string: token))
+                    self.usersCache?.setObject(newCacheElement, forKey: NSString(string: token))
                 #endif
                 onSuccess(userProfile)
             }

--- a/Tests/CredentialsTests/TestSession.swift
+++ b/Tests/CredentialsTests/TestSession.swift
@@ -43,10 +43,10 @@ class TestSession : XCTestCase {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", host: self.host, path: "/private/data", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Dummy User is logged in with DummySession</b></body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Dummy User is logged in with DummySession</b></body></html>\n\n")
                 }
                 catch{
                     XCTFail("No response body")

--- a/Tests/CredentialsTests/TestToken.swift
+++ b/Tests/CredentialsTests/TestToken.swift
@@ -41,10 +41,10 @@ class TestToken : XCTestCase {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/user", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Dummy User is logged in with DummyToken</b></body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body,"<!DOCTYPE html><html><body><b>Dummy User is logged in with DummyToken</b></body></html>\n\n")
                 }
                 catch{
                     XCTFail("No response body")
@@ -58,7 +58,7 @@ class TestToken : XCTestCase {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", path:"/private/user", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
                 }, headers: ["X-token-type" : "DummyToken", "access_token" : "wrongToken"])
         }

--- a/Tests/CredentialsTests/TestUnauthorizedSession.swift
+++ b/Tests/CredentialsTests/TestUnauthorizedSession.swift
@@ -46,7 +46,7 @@ class TestUnauthorizedSession : XCTestCase {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", host: self.host, path: "/private/data", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(String(describing: response?.statusCode))")
 
                 expectation.fulfill()
             })
@@ -58,7 +58,7 @@ class TestUnauthorizedSession : XCTestCase {
         performServerTest(router: router) { expectation in
             self.performRequest(method: "get", host: self.host, path: "/private/data", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(String(describing: response?.statusCode))")
 
                 expectation.fulfill()
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix String interpolation warnings on 3.1; remove force unwraps

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
