### PR TITLE
IBM-Swift/Kitura-Credentials#45 Only log error that there is no sessi…

### DIFF
--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -114,7 +114,9 @@ public class Credentials : RouterMiddleware {
                     self.redirectUnauthorized(response: response)
                 }
                 else {
-                    Log.error("The authentication failed either because the authentication data was not recognized by any non-redirecting plugin, or because a session, required by redirecting authentication, was not configured.")
+                    if request.session == nil && !self.redirectingPlugins.isEmpty && self.nonRedirectingPlugins.isEmpty {
+                        Log.error("The authentication failed because a session, required by redirecting authentication, was not configured.")
+                    }
                     self.fail(response: response, status: passStatus, headers: passHeaders)
                 }
             }


### PR DESCRIPTION
…on, if there is redirecting plugin and there are no non-redirecting plugins

IBM-Swift/Kitura-Credentials#45

## Description
Improve error logging. Only log an error if there is no session, there is at least one redirecting plugin, and there are no non-redirecting plugins. Otherwise, don't log anything.

## Motivation and Context
The previous message was confusing.

## How Has This Been Tested?
Tested on macOS and Linux.
