### PR TITLE
Extract user profile from session

### DIFF
--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -66,7 +66,7 @@ public class Credentials : RouterMiddleware {
                 return
             }
             else {
-                if let userProfile = restoreUserProfile(from: session) {
+                if let userProfile = Credentials.restoreUserProfile(from: session) {
                     request.userProfile = userProfile
                     next()
                     return
@@ -243,7 +243,7 @@ public class Credentials : RouterMiddleware {
                 if let plugin = self.redirectingPlugins[credentialsType] {
                     plugin.authenticate(request: request, response: response, options: self.options,
                                         onSuccess: { userProfile in
-                                            self.store(userProfile: userProfile, in: session)
+                                            Credentials.store(userProfile: userProfile, in: session)
                                             var redirect: String?
                                             if let returnTo = Credentials.getRedirectingReturnTo(for: request) {
                                                 redirect = returnTo
@@ -299,7 +299,7 @@ public class Credentials : RouterMiddleware {
         }
     }
     
-    private func restoreUserProfile(from session: SessionState) -> UserProfile? {
+    static func restoreUserProfile(from session: SessionState) -> UserProfile? {
         let sessionUserProfile = session["userProfile"]
         if sessionUserProfile.type != .null  {
             if let dictionary = sessionUserProfile.dictionaryObject,
@@ -343,7 +343,7 @@ public class Credentials : RouterMiddleware {
         return nil
     }
     
-    private func store(userProfile: UserProfile, in session: SessionState) {
+    private static func store(userProfile: UserProfile, in session: SessionState) {
         var dictionary = [String:Any]()
         dictionary["displayName"] = userProfile.displayName
         dictionary["provider"] = userProfile.provider

--- a/Sources/Credentials/RouterRequest+UserProfile.swift
+++ b/Sources/Credentials/RouterRequest+UserProfile.swift
@@ -29,7 +29,16 @@ public extension RouterRequest {
     /// `UserProfile` information of authenticated users.
     public internal(set) var userProfile: UserProfile? {
         get {
-            return userInfo[USER_PROFILE_USER_INFO_KEY] as? UserProfile
+            if let requestUserProfile = userInfo[USER_PROFILE_USER_INFO_KEY] as? UserProfile {
+                return requestUserProfile
+            }
+            
+            if let session = session,
+                let sessionUserProfile = Credentials.restoreUserProfile(from: session) {
+                return sessionUserProfile
+            }
+            
+            return nil
         }
         set {
             userInfo[USER_PROFILE_USER_INFO_KEY] = newValue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
IBM-Swift/Kitura-Credentials#49 

At the moment user profile is stored in a router request by Credentials middleware. If the middleware is not set on a path, requests to this path don't have user profile even if they are authenticated. This PR extracts user profile from the request's session if exists.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.