### PR TITLE
Broaden Kitura-Session version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-      .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", .upToNextMinor(from: "2.0.0")),
+      .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "2.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## Description
Changed the Package.swift to target 2.x of Kitura-Session instead of 2.0.x.

## Motivation and Context
I don't see any reason to restrict the version range to minors and having a broader range here would prevent the need to update this package for every minor release of Kitura-Session.

## How Has This Been Tested?
Tested with `swift test`.


  