### PR TITLE
Add Kitura-CredentialsLocal to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,14 @@ router.post("/collection/:new") {request, response, next in
 ## List of plugins:
 
 * [Facebook OAuth2 Authorization Code flow login](https://github.com/IBM-Swift/Kitura-CredentialsFacebook)
-
 * [Facebook OAuth2 token](https://github.com/IBM-Swift/Kitura-CredentialsFacebook)
-
 * [GitHub OAuth2 Authorization Code flow login](https://github.com/IBM-Swift/Kitura-CredentialsGitHub)
-
 * [Google OAuth2 Authorization Code flow login](https://github.com/IBM-Swift/Kitura-CredentialsGoogle)
-
 * [Google OAuth2 token](https://github.com/IBM-Swift/Kitura-CredentialsGoogle)
-
 * [HTTP Basic authentication](https://github.com/IBM-Swift/Kitura-CredentialsHTTP)
-
 * [HTTP Digest authentication](https://github.com/IBM-Swift/Kitura-CredentialsHTTP)
-
 * [Twitter OAuth](https://github.com/jacobvanorder/Kitura-CredentialsTwitter) (Third-party implemented)
+* [Local authentication](https://github.com/NocturnalSolutions/Kitura-CredentialsLocal) (For credentials stored in e.g. a local database; third-party implemented)
 
 ## License
 This library is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE.txt).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds [Kitura Credentials Local](https://github.com/NocturnalSolutions/Kitura-CredentialsLocal) to the plugin list in README.md. Fixes formatting of the list while I'm at it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To increase awareness of the availability of this plugin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Looked at the formatted README.md in my repo and don't seem to have screwed anything up.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.