### PR TITLE
stop leaking memory by avoiding retain cycle in callback referring to itself

### DIFF
--- a/Sources/Credentials/Credentials.swift
+++ b/Sources/Credentials/Credentials.swift
@@ -84,10 +84,12 @@ public class Credentials : RouterMiddleware {
                 let plugin = self.nonRedirectingPlugins[pluginIndex]
                 plugin.authenticate(request: request, response: response, options: self.options,
                                     onSuccess: { userProfile in
+                                        callback = nil
                                         request.userProfile = userProfile
                                         next()
                     },
                                     onFailure: { status, headers in
+                                        callback = nil
                                         self.fail(response: response, status: status, headers: headers)
                     },
                                     onPass: { status, headers in
@@ -99,6 +101,7 @@ public class Credentials : RouterMiddleware {
                                         callback!()
                     },
                                     inProgress: {
+                                        callback = nil
                                         self.redirectUnauthorized(response: response)
                                         next()
                     }
@@ -106,6 +109,7 @@ public class Credentials : RouterMiddleware {
             }
             else {
                 // All the plugins passed
+                callback = nil
                 if request.session != nil, !self.redirectingPlugins.isEmpty {
                     Credentials.setRedirectingReturnTo(request.originalURL, for: request)
                     self.redirectUnauthorized(response: response)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mu Kitura based HTTPS server with basic auth has been leaking memory for the past months and I finally found a time to investigate. The sample project https://github.com/mman/leaky-kitura demonstrates this issue nicely.

## Motivation and Context

The line https://github.com/IBM-Swift/Kitura-Credentials/blob/master/Sources/Credentials/Credentials.swift#L99 creates a retain cycle that from my investigation keeps all requests in memory eating the memory with every authenticated request passing through Credentials.handle method.

Tested using malloc debugger in Xcode 9.2 and Xcode 9.3 as well as in instruments. With this proposed change the process memory usage remains stable.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.