### PR TITLE
fix: update package.swift for typeSafeMiddleware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-      .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.0.0"),
+      .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.2.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
The latest version of Credentials requires Kitura 2.4

We currently rely on Sessions to bring in Kitura and so need to update Sessions to 3.2 so that sessions requires Kitura 2.4 to ensure we also get 2.4