### PR TITLE
Add Swift 4.2 snapshots to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,12 @@ matrix:
       osx_image: xcode9.4
       sudo: required
       env: JAZZY_ELIGIBLE=true
-    - os: osx
-      osx_image: xcode9.4
-      sudo: required
-      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-04-a
+# BlueCryptor requires xcode10 with Swift 4.2, but there is not yet a Travis
+# image available - see: https://github.com/travis-ci/travis-ci/issues/9730
+#    - os: osx
+#      osx_image: xcode9.4
+#      sudo: required
+#      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-04-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ branches:
     - develop
     - /^issue.*$/
 
-notifications:
-  slack:
-    secure: "e6LnSUjiA/wZRVaJN9bdbzKrJxtl1D0sBosHs9BERIsek2VMgCN1Z4eFJk9ul/ePIEciaFWgOwJJO9ltC/tRburseDcgzSFNXO1hMasUvA+N3D8wxgnMTdzMnv+F7vbn613kuHFMRFoJFR1TWqahhlUGXvQFvGN+bx2InpZ8qcDmKGbWdk2LgIjF0lm9x+9hAlSKhcO9Dw93qQL8EGkmVJyhoYKL1usJbtpcFiJu6PQhmwM5JSH+5h0GISCoYsv+CKunqcBLfXeFyqT2LuZ1TcWXD3A0PCQQz3imOWhP4eZX9IyQS+E0ypOV8VqvUEyyl0v0Eirmjvh4smTQLlqWVITZe4BGri9+2V4rOocQK8HDbDeH1VuoXa36n9zJDDaMHoixank6n259YFhz5VgekVBMU3lGOvZ4+ax235cmOrF6WtRkY4oN+9AxoZ687A0164l3o+VoPJkpNdu2PZ8n2U2ATfYyqTUwluGPmVhS9YwkhMvDyEOu/EBxG0WcZjlAYQ4Ka2K2hiapulkqACYTeBU5cqMgkY4FOcwXzRqtEBSM0QPSxPFZoF2wNxPFc5DbNBXqRcaBjfyjgXjNhqrbVjHbE0iuM6vtAxXdRU6wrUIKx65cfa6vG/k8rfPG1kBpW2RQtC5s0tsTwBt+4ZUWNbWGzlSe01EkLr5CstzeG/A="
-
 matrix:
   include:
     - os: linux
@@ -21,14 +17,22 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-26-a
     - os: osx
       osx_image: xcode9.2
       sudo: required
       env: SWIFT_SNAPSHOT=4.0.3
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1 JAZZY_ELIGIBLE=true
+      env: JAZZY_ELIGIBLE=true
+    - os: osx
+      osx_image: xcode9.4
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-04-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
- Add latest Swift 4.2 snapshot to Travis (Linux)
- Add Swift 4.2 06-04-a snapshot for macOS (the latest supported under Xcode 9.4)
