### PR TITLE
feat: Added createdAt timestamp to cache element

### DIFF
--- a/Sources/Credentials/BaseCacheElement.swift
+++ b/Sources/Credentials/BaseCacheElement.swift
@@ -15,17 +15,22 @@
  **/
 
 // MARK BaseCacheElement
+import Foundation
 
 /// The cache element for keeping user profile information.
 public class BaseCacheElement {
     /// The user profile information stored as `UserProfile`.
     public var userProfile: UserProfile
     
+    /// The time the UserProfile was originally created
+    public var createdAt: Date
+    
     /// Initialize a `BaseCacheElement`.
     ///
     /// - Parameter profile: the `UserProfile` to store.
     public init (profile: UserProfile) {
         userProfile = profile
+        createdAt = Date()
     }
 }
 


### PR DESCRIPTION
## Description
This change adds a timestamp to the BaseCacheElement with the time that the user profile was created. This can then be used either by the user or by a plugin implementation to clear elements of the cache if they have not been used for a certain period of time.

## Motivation and Context
This has bee added in response to issue #75. Once a credentials has validated a token it will trust and link that token to the user profile indefinitely. This means if the token is later revoked by the provider, this will not be picked up by Credentials.

