### PR TITLE
Add credential middleware registration order note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ router.post("/collection/:new") {request, response, next in
 }
 ```
 
+> **NOTE**: The credential middleware must be registered before any route handlers, as shown in the example above. Failure to register the credential middleware before other route handlers may cause exposure of unauthorized data on protected routes.
+
 ## List of plugins:
 
 * [Facebook OAuth2 Authorization Code flow login](https://github.com/IBM-Swift/Kitura-CredentialsFacebook)


### PR DESCRIPTION
The order in which credential middleware is registered can impact how Kitura responds to unauthorized requests.

For example, if HTTP Basic auth credential middleware is registered after the normal route handler, the body of the response may be populated with sensitive data before the credentials are checked. This situation can occur when a user cancels a basic auth prompt, yielding a response with a 401 status code and a body populated with unauthorized data.

For additional details, see: https://github.com/IBM-Swift/Kitura-CredentialsHTTP/issues/59

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
